### PR TITLE
Added Necessary Timezones

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS locations (
     city_name VARCHAR(100) NOT NULL,
     country VARCHAR(100) NOT NULL,
     airport_name VARCHAR(200) NOT NULL,
+    timezone VARCHAR(100) NOT NULL COMMENT 'IANA timezone format, e.g., America/New_York',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     );
 
@@ -30,6 +31,19 @@ CREATE TABLE IF NOT EXISTS reservations (
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
     );
+
+CREATE TABLE IF NOT EXISTS bookings (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id BIGINT NOT NULL,
+    flight_number VARCHAR(50) NOT NULL,
+    depart_airport VARCHAR(255) NOT NULL,
+    arrive_airport VARCHAR(255) NOT NULL,
+    depart_datetime DATETIME NOT NULL,
+    arrive_datetime DATETIME NOT NULL,
+    status VARCHAR(50) DEFAULT 'Confirmed',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
 
 CREATE TABLE `deltas` (
                           `Id` int NOT NULL AUTO_INCREMENT,
@@ -50,4 +64,3 @@ CREATE TABLE `southwests` (
                               `FlightNumber` varchar(255) NOT NULL,
                               PRIMARY KEY (`Id`)
 );
-


### PR DESCRIPTION
This PR updates the locations table schema to include a new column timezone, which stores the airport’s local time offset in GMT±HH:MM format (e.g., GMT -05:00). This change enables the system to better manage time-related functionalities like flight scheduling, bookings, and user notifications across different time zones.